### PR TITLE
default to RelWithDebInfo for cmake build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(Set-Toolchain-vcpkg)
 project(BitcoinArmory C CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release CACHE STRING "Release version" FORCE)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Release with debug info version" FORCE)
 endif()
 
 if(POLICY CMP0077)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -14,7 +14,7 @@
     }, {
       "name": "x64-Release",
       "generator": "Visual Studio 15 2017",
-      "configurationType": "Release",
+      "configurationType": "RelWithDebInfo",
       "inheritEnvironments": [
         "msvc_x64"
       ],
@@ -36,7 +36,7 @@
     }, {
       "name": "x86-Release",
       "generator": "Visual Studio 15 2017",
-      "configurationType": "Release",
+      "configurationType": "RelWithDebInfo",
       "inheritEnvironments": [
         "msvc_x86"
       ],


### PR DESCRIPTION
This is a better default than `Release`, also distributions usually use
it to also make debug info packages.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>