### PR TITLE
update lmdb to version 0.9.24

### DIFF
--- a/cppForSwig/lmdb/libraries/liblmdb/COPYRIGHT
+++ b/cppForSwig/lmdb/libraries/liblmdb/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright 2011-2018 Howard Chu, Symas Corp.
+Copyright 2011-2019 Howard Chu, Symas Corp.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cppForSwig/lmdb/libraries/liblmdb/lmdb.h
+++ b/cppForSwig/lmdb/libraries/liblmdb/lmdb.h
@@ -136,7 +136,7 @@
  *
  *	@author	Howard Chu, Symas Corporation.
  *
- *	@copyright Copyright 2011-2018 Howard Chu, Symas Corp. All rights reserved.
+ *	@copyright Copyright 2011-2019 Howard Chu, Symas Corp. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted only as authorized by the OpenLDAP

--- a/cppForSwig/lmdb/libraries/liblmdb/lmdb.h
+++ b/cppForSwig/lmdb/libraries/liblmdb/lmdb.h
@@ -332,8 +332,8 @@ typedef void (MDB_rel_func)(MDB_val *item, void *oldptr, void *newptr, void *rel
 #define MDB_NORDAHEAD	0x800000
 	/** don't initialize malloc'd memory before writing to datafile */
 #define MDB_NOMEMINIT	0x1000000
-	/** use the previous meta page rather than the latest one */
-#define MDB_PREVMETA	0x2000000
+	/** use the previous snapshot rather than the latest one */
+#define MDB_PREVSNAPSHOT	0x2000000
 /** @} */
 
 /**	@defgroup	mdb_dbi_open	Database Flags
@@ -648,10 +648,12 @@ int  mdb_env_create(MDB_env **env);
 	 *		caller is expected to overwrite all of the memory that was
 	 *		reserved in that case.
 	 *		This flag may be changed at any time using #mdb_env_set_flags().
-	 *	<li>#MDB_PREVMETA
-	 *		Open the environment with the previous meta page rather than the latest
+	 *	<li>#MDB_PREVSNAPSHOT
+	 *		Open the environment with the previous snapshot rather than the latest
 	 *		one. This loses the latest transaction, but may help work around some
-	 *		types of corruption.
+	 *		types of corruption. If opened with write access, this must be the
+	 *		only process using the environment. This flag is automatically reset
+	 *		after a write transaction is successfully committed.
 	 * </ul>
 	 * @param[in] mode The UNIX permissions to set on created files and semaphores.
 	 * This parameter is ignored on Windows.

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb.c
@@ -144,7 +144,7 @@ typedef SSIZE_T	ssize_t;
 #include <unistd.h>
 #endif
 
-#if defined(__sun) || defined(ANDROID)
+#if defined(__sun) || defined(__ANDROID__)
 /* Most platforms have posix_memalign, older may only have memalign */
 #define HAVE_MEMALIGN	1
 #include <malloc.h>
@@ -164,7 +164,7 @@ typedef SSIZE_T	ssize_t;
 # define MDB_USE_SYSV_SEM	1
 # endif
 # define MDB_FDATASYNC		fsync
-#elif defined(ANDROID)
+#elif defined(__ANDROID__)
 # define MDB_FDATASYNC		fsync
 #endif
 
@@ -310,7 +310,7 @@ union semun {
  */
 #ifndef MDB_USE_ROBUST
 /* Android currently lacks Robust Mutex support. So does glibc < 2.4. */
-# if defined(MDB_USE_POSIX_MUTEX) && (defined(ANDROID) || \
+# if defined(MDB_USE_POSIX_MUTEX) && (defined(__ANDROID__) || \
 	(defined(__GLIBC__) && GLIBC_VER < 0x020004))
 #  define MDB_USE_ROBUST	0
 # else

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb.c
@@ -4741,7 +4741,7 @@ mdb_env_open2(MDB_env *env, int prev)
 		env->me_pidquery = PROCESS_QUERY_INFORMATION;
 	/* Grab functions we need from NTDLL */
 	if (!NtCreateSection) {
-		HMODULE h = GetModuleHandle("NTDLL.DLL");
+		HMODULE h = GetModuleHandleW(L"NTDLL.DLL");
 		if (!h)
 			return MDB_PROBLEM;
 		NtClose = (NtCloseFunc *)GetProcAddress(h, "NtClose");

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb.c
@@ -3793,6 +3793,8 @@ done:
 	return MDB_SUCCESS;
 }
 
+static int ESECT mdb_env_share_locks(MDB_env *env, int *excl);
+
 int
 mdb_txn_commit(MDB_txn *txn)
 {
@@ -4015,6 +4017,15 @@ mdb_txn_commit(MDB_txn *txn)
 	if ((rc = mdb_env_write_meta(txn)))
 		goto fail;
 	end_mode = MDB_END_COMMITTED|MDB_END_UPDATE;
+	if (env->me_flags & MDB_PREVSNAPSHOT) {
+		if (!(env->me_flags & MDB_NOLOCK)) {
+			int excl;
+			rc = mdb_env_share_locks(env, &excl);
+			if (rc)
+				goto fail;
+		}
+		env->me_flags ^= MDB_PREVSNAPSHOT;
+	}
 
 done:
 	mdb_txn_end(txn, end_mode);
@@ -4296,7 +4307,8 @@ static MDB_meta *
 mdb_env_pick_meta(const MDB_env *env)
 {
 	MDB_meta *const *metas = env->me_metas;
-	return metas[ metas[0]->mm_txnid < metas[1]->mm_txnid ];
+	return metas[ (metas[0]->mm_txnid < metas[1]->mm_txnid) ^
+		((env->me_flags & MDB_PREVSNAPSHOT) != 0) ];
 }
 
 int ESECT
@@ -4868,6 +4880,9 @@ mdb_env_open2(MDB_env *env, int prev)
 #endif
 	env->me_maxpg = env->me_mapsize / env->me_psize;
 
+	if (env->me_txns)
+		env->me_txns->mti_txnid = meta.mm_txnid;
+
 #if MDB_DEBUG
 	{
 		MDB_meta *meta = mdb_env_pick_meta(env);
@@ -4967,9 +4982,6 @@ static int ESECT
 mdb_env_share_locks(MDB_env *env, int *excl)
 {
 	int rc = 0;
-	MDB_meta *meta = mdb_env_pick_meta(env);
-
-	env->me_txns->mti_txnid = meta->mm_txnid;
 
 #ifdef _WIN32
 	{
@@ -5391,7 +5403,7 @@ fail:
 	 */
 #define	CHANGEABLE	(MDB_NOSYNC|MDB_NOMETASYNC|MDB_MAPASYNC|MDB_NOMEMINIT)
 #define	CHANGELESS	(MDB_FIXEDMAP|MDB_NOSUBDIR|MDB_RDONLY| \
-	MDB_WRITEMAP|MDB_NOTLS|MDB_NOLOCK|MDB_NORDAHEAD|MDB_PREVMETA)
+	MDB_WRITEMAP|MDB_NOTLS|MDB_NOLOCK|MDB_NORDAHEAD|MDB_PREVSNAPSHOT)
 
 #if VALID_FLAGS & PERSISTENT_FLAGS & (CHANGEABLE|CHANGELESS)
 # error "Persistent DB flags & env flags overlap, but both go in mm_flags"
@@ -5477,6 +5489,10 @@ mdb_env_open(MDB_env *env, const char *path, unsigned int flags, mdb_mode_t mode
 		rc = mdb_env_setup_locks(env, &fname, mode, &excl);
 		if (rc)
 			goto leave;
+		if ((flags & MDB_PREVSNAPSHOT) && !excl) {
+			rc = EAGAIN;
+			goto leave;
+		}
 	}
 
 	rc = mdb_fopen(env, &fname,
@@ -5491,7 +5507,7 @@ mdb_env_open(MDB_env *env, const char *path, unsigned int flags, mdb_mode_t mode
 			goto leave;
 	}
 
-	if ((rc = mdb_env_open2(env, flags & MDB_PREVMETA)) == MDB_SUCCESS) {
+	if ((rc = mdb_env_open2(env, flags & MDB_PREVSNAPSHOT)) == MDB_SUCCESS) {
 		if (!(flags & (MDB_RDONLY|MDB_WRITEMAP))) {
 			/* Synchronous fd for meta writes. Needed even with
 			 * MDB_NOSYNC/MDB_NOMETASYNC, in case these get reset.
@@ -5501,7 +5517,7 @@ mdb_env_open(MDB_env *env, const char *path, unsigned int flags, mdb_mode_t mode
 				goto leave;
 		}
 		DPRINTF(("opened dbenv %p", (void *) env));
-		if (excl > 0) {
+		if (excl > 0 && !(flags & MDB_PREVSNAPSHOT)) {
 			rc = mdb_env_share_locks(env, &excl);
 			if (rc)
 				goto leave;

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb.c
@@ -3459,9 +3459,9 @@ mdb_freelist_save(MDB_txn *txn)
 			} else {
 				x = mdb_mid2l_search(dl, mp->mp_pgno);
 				mdb_tassert(txn, dl[x].mid == mp->mp_pgno);
+				mdb_dpage_free(env, mp);
 			}
 			dl[x].mptr = NULL;
-			mdb_dpage_free(env, mp);
 		}
 		{
 			/* squash freed slots out of the dirty list */

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb.c
@@ -5,7 +5,7 @@
  *	BerkeleyDB API, but much simplified.
  */
 /*
- * Copyright 2011-2018 Howard Chu, Symas Corp.
+ * Copyright 2011-2019 Howard Chu, Symas Corp.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb.c
@@ -9641,7 +9641,7 @@ mdb_page_split(MDB_cursor *mc, MDB_val *newkey, MDB_val *newdata, pgno_t newpgno
 			 * the split so the new page is emptier than the old page.
 			 * This yields better packing during sequential inserts.
 			 */
-			if (nkeys < 20 || nsize > pmax/16 || newindx >= nkeys) {
+			if (nkeys < 32 || nsize > pmax/16 || newindx >= nkeys) {
 				/* Find split point */
 				psize = 0;
 				if (newindx <= split_indx || newindx >= nkeys) {

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb.c
@@ -7472,7 +7472,7 @@ mdb_cursor_put(MDB_cursor *mc, MDB_val *key, MDB_val *data,
 
 	dkey.mv_size = 0;
 
-	if (flags == MDB_CURRENT) {
+	if (flags & MDB_CURRENT) {
 		if (!(mc->mc_flags & C_INITIALIZED))
 			return EINVAL;
 		rc = MDB_SUCCESS;
@@ -7865,7 +7865,7 @@ put_sub:
 			xdata.mv_size = 0;
 			xdata.mv_data = "";
 			leaf = NODEPTR(mc->mc_pg[mc->mc_top], mc->mc_ki[mc->mc_top]);
-			if (flags & MDB_CURRENT) {
+			if (flags == MDB_CURRENT) {
 				xflags = MDB_CURRENT|MDB_NOSPILL;
 			} else {
 				mdb_xcursor_init1(mc, leaf);

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_copy.1
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_copy.1
@@ -1,5 +1,5 @@
-.TH MDB_COPY 1 "2014/07/01" "LMDB 0.9.14"
-.\" Copyright 2012-2018 Howard Chu, Symas Corp. All Rights Reserved.
+.TH MDB_COPY 1 "2017/07/31" "LMDB 0.9.70"
+.\" Copyright 2012-2019 Howard Chu, Symas Corp. All Rights Reserved.
 .\" Copying restrictions apply.  See COPYRIGHT/LICENSE.
 .SH NAME
 mdb_copy \- LMDB environment copy tool
@@ -11,6 +11,8 @@ mdb_copy \- LMDB environment copy tool
 .BR \-c ]
 [\c
 .BR \-n ]
+[\c
+.BR \-v ]
 .B srcpath
 [\c
 .BR dstpath ]
@@ -40,6 +42,10 @@ Currently it fails if the environment has suffered a page leak.
 .TP
 .BR \-n
 Open LDMB environment(s) which do not use subdirectories.
+.TP
+.BR \-v
+Use the previous environment state instead of the latest state.
+This may be useful if the latest state has been corrupted.
 
 .SH DIAGNOSTICS
 Exit status is zero if no errors occur.

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_copy.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_copy.c
@@ -39,7 +39,7 @@ int main(int argc,char * argv[])
 		if (argv[1][1] == 'n' && argv[1][2] == '\0')
 			flags |= MDB_NOSUBDIR;
 		else if (argv[1][1] == 'v' && argv[1][2] == '\0')
-			flags |= MDB_PREVMETA;
+			flags |= MDB_PREVSNAPSHOT;
 		else if (argv[1][1] == 'c' && argv[1][2] == '\0')
 			cpflags |= MDB_CP_COMPACT;
 		else if (argv[1][1] == 'V' && argv[1][2] == '\0') {

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_copy.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_copy.c
@@ -38,6 +38,8 @@ int main(int argc,char * argv[])
 	for (; argc > 1 && argv[1][0] == '-'; argc--, argv++) {
 		if (argv[1][1] == 'n' && argv[1][2] == '\0')
 			flags |= MDB_NOSUBDIR;
+		else if (argv[1][1] == 'v' && argv[1][2] == '\0')
+			flags |= MDB_PREVMETA;
 		else if (argv[1][1] == 'c' && argv[1][2] == '\0')
 			cpflags |= MDB_CP_COMPACT;
 		else if (argv[1][1] == 'V' && argv[1][2] == '\0') {
@@ -48,7 +50,7 @@ int main(int argc,char * argv[])
 	}
 
 	if (argc<2 || argc>3) {
-		fprintf(stderr, "usage: %s [-V] [-c] [-n] srcpath [dstpath]\n", progname);
+		fprintf(stderr, "usage: %s [-V] [-c] [-n] [-v] srcpath [dstpath]\n", progname);
 		exit(EXIT_FAILURE);
 	}
 

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_dump.1
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_dump.1
@@ -1,5 +1,5 @@
-.TH MDB_DUMP 1 "2015/09/30" "LMDB 0.9.17"
-.\" Copyright 2014-2018 Howard Chu, Symas Corp. All Rights Reserved.
+.TH MDB_DUMP 1 "2017/07/31" "LMDB 0.9.70"
+.\" Copyright 2014-2017 Howard Chu, Symas Corp. All Rights Reserved.
 .\" Copying restrictions apply.  See COPYRIGHT/LICENSE.
 .SH NAME
 mdb_dump \- LMDB environment export tool
@@ -13,6 +13,8 @@ mdb_dump \- LMDB environment export tool
 .BR \-l ]
 [\c
 .BR \-n ]
+[\c
+.BR \-v ]
 [\c
 .BR \-p ]
 [\c
@@ -41,6 +43,10 @@ names will be listed, no data will be output.
 .TP
 .BR \-n
 Dump an LMDB database which does not use subdirectories.
+.TP
+.BR \-v
+Use the previous environment state instead of the latest state.
+This may be useful if the latest state has been corrupted.
 .TP
 .BR \-p
 If characters in either the key or data items are printing characters (as

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_dump.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_dump.c
@@ -64,6 +64,8 @@ static void text(MDB_val *v)
 	end = c + v->mv_size;
 	while (c < end) {
 		if (isprint(*c)) {
+			if (*c == '\\')
+				putchar('\\');
 			putchar(*c);
 		} else {
 			putchar('\\');

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_dump.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_dump.c
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
 	 * -n: use NOSUBDIR flag on env_open
 	 * -p: use printable characters
 	 * -f: write to file instead of stdout
-	 * -v: use previous metapage
+	 * -v: use previous snapshot
 	 * -V: print version and exit
 	 * (default) dump only the main DB
 	 */
@@ -204,7 +204,7 @@ int main(int argc, char *argv[])
 			envflags |= MDB_NOSUBDIR;
 			break;
 		case 'v':
-			envflags |= MDB_PREVMETA;
+			envflags |= MDB_PREVSNAPSHOT;
 			break;
 		case 'p':
 			mode |= PRINT;

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_dump.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_dump.c
@@ -151,7 +151,7 @@ static int dumpit(MDB_txn *txn, MDB_dbi dbi, char *name)
 
 static void usage(char *prog)
 {
-	fprintf(stderr, "usage: %s [-V] [-f output] [-l] [-n] [-p] [-a|-s subdb] dbpath\n", prog);
+	fprintf(stderr, "usage: %s [-V] [-f output] [-l] [-n] [-p] [-v] [-a|-s subdb] dbpath\n", prog);
 	exit(EXIT_FAILURE);
 }
 
@@ -175,6 +175,7 @@ int main(int argc, char *argv[])
 	 * -n: use NOSUBDIR flag on env_open
 	 * -p: use printable characters
 	 * -f: write to file instead of stdout
+	 * -v: use previous metapage
 	 * -V: print version and exit
 	 * (default) dump only the main DB
 	 */
@@ -201,6 +202,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'n':
 			envflags |= MDB_NOSUBDIR;
+			break;
+		case 'v':
+			envflags |= MDB_PREVMETA;
 			break;
 		case 'p':
 			mode |= PRINT;

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_load.1
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_load.1
@@ -37,6 +37,13 @@ option below.
 .BR \-V
 Write the library version number to the standard output, and exit.
 .TP
+.BR \-a
+Append all records in the order they appear in the input. The input is assumed to already be
+in correctly sorted order and no sorting or checking for redundant values will be performed.
+This option must be used to reload data that was produced by running
+.B mdb_dump
+on a database that uses custom compare functions.
+.TP
 .BR \-f \ file
 Read from the specified file instead of from the standard input.
 .TP

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_load.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_load.c
@@ -236,7 +236,7 @@ badend:
 		while (c2 < end) {
 			if (*c2 == '\\') {
 				if (c2[1] == '\\') {
-					c1++; c2 += 2;
+					*c1++ = *c2;
 				} else {
 					if (c2+3 > end || !isxdigit(c2[1]) || !isxdigit(c2[2])) {
 						Eof = 1;
@@ -244,8 +244,8 @@ badend:
 						return EOF;
 					}
 					*c1++ = unhex(++c2);
-					c2 += 2;
 				}
+				c2 += 2;
 			} else {
 				/* copies are redundant when no escapes were used */
 				*c1++ = *c2++;

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_load.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_load.c
@@ -386,7 +386,6 @@ int main(int argc, char *argv[])
 	while(!Eof) {
 		MDB_val key, data;
 		int batch = 0;
-		flags = 0;
 		int appflag;
 
 		if (!dohdr) {

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_load.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_load.c
@@ -37,6 +37,7 @@ static int Eof;
 static MDB_envinfo info;
 
 static MDB_val kbuf, dbuf;
+static MDB_val k0buf;
 
 #define Yu	MDB_PRIy(u)
 
@@ -275,8 +276,13 @@ badend:
 
 static void usage(void)
 {
-	fprintf(stderr, "usage: %s [-V] [-f input] [-n] [-s name] [-N] [-T] dbpath\n", prog);
+	fprintf(stderr, "usage: %s [-V] [-a] [-f input] [-n] [-s name] [-N] [-T] dbpath\n", prog);
 	exit(EXIT_FAILURE);
+}
+
+static int greater(const MDB_val *a, const MDB_val *b)
+{
+	return 1;
 }
 
 int main(int argc, char *argv[])
@@ -287,8 +293,9 @@ int main(int argc, char *argv[])
 	MDB_cursor *mc;
 	MDB_dbi dbi;
 	char *envname;
-	int envflags = 0, putflags = 0;
-	int dohdr = 0;
+	int envflags = MDB_NOSYNC, putflags = 0;
+	int dohdr = 0, append = 0;
+	MDB_val prevk;
 
 	prog = argv[0];
 
@@ -296,18 +303,22 @@ int main(int argc, char *argv[])
 		usage();
 	}
 
-	/* -f: load file instead of stdin
+	/* -a: append records in input order
+	 * -f: load file instead of stdin
 	 * -n: use NOSUBDIR flag on env_open
 	 * -s: load into named subDB
 	 * -N: use NOOVERWRITE on puts
 	 * -T: read plaintext
 	 * -V: print version and exit
 	 */
-	while ((i = getopt(argc, argv, "f:ns:NTV")) != EOF) {
+	while ((i = getopt(argc, argv, "af:ns:NTV")) != EOF) {
 		switch(i) {
 		case 'V':
 			printf("%s\n", MDB_VERSION_STRING);
 			exit(0);
+			break;
+		case 'a':
+			append = 1;
 			break;
 		case 'f':
 			if (freopen(optarg, "r", stdin) == NULL) {
@@ -367,11 +378,16 @@ int main(int argc, char *argv[])
 	}
 
 	kbuf.mv_size = mdb_env_get_maxkeysize(env) * 2 + 2;
-	kbuf.mv_data = malloc(kbuf.mv_size);
+	kbuf.mv_data = malloc(kbuf.mv_size * 2);
+	k0buf.mv_size = kbuf.mv_size;
+	k0buf.mv_data = (char *)kbuf.mv_data + kbuf.mv_size;
+	prevk.mv_data = k0buf.mv_data;
 
 	while(!Eof) {
 		MDB_val key, data;
 		int batch = 0;
+		flags = 0;
+		int appflag;
 
 		if (!dohdr) {
 			dohdr = 1;
@@ -388,6 +404,12 @@ int main(int argc, char *argv[])
 		if (rc) {
 			fprintf(stderr, "mdb_open failed, error %d %s\n", rc, mdb_strerror(rc));
 			goto txn_abort;
+		}
+		prevk.mv_size = 0;
+		if (append) {
+			mdb_set_compare(txn, dbi, greater);
+			if (flags & MDB_DUPSORT)
+				mdb_set_dupsort(txn, dbi, greater);
 		}
 
 		rc = mdb_cursor_open(txn, dbi, &mc);
@@ -407,7 +429,20 @@ int main(int argc, char *argv[])
 				goto txn_abort;
 			}
 
-			rc = mdb_cursor_put(mc, &key, &data, putflags);
+			if (append) {
+				appflag = MDB_APPEND;
+				if (flags & MDB_DUPSORT) {
+					if (prevk.mv_size == key.mv_size && !memcmp(prevk.mv_data, key.mv_data, key.mv_size))
+						appflag = MDB_CURRENT|MDB_APPENDDUP;
+					else {
+						memcpy(prevk.mv_data, key.mv_data, key.mv_size);
+						prevk.mv_size = key.mv_size;
+					}
+				}
+			} else {
+				appflag = 0;
+			}
+			rc = mdb_cursor_put(mc, &key, &data, putflags|appflag);
 			if (rc == MDB_KEYEXIST && putflags)
 				continue;
 			if (rc) {
@@ -431,6 +466,10 @@ int main(int argc, char *argv[])
 				if (rc) {
 					fprintf(stderr, "mdb_cursor_open failed, error %d %s\n", rc, mdb_strerror(rc));
 					goto txn_abort;
+				}
+				if (appflag & MDB_APPENDDUP) {
+					MDB_val k, d;
+					mdb_cursor_get(mc, &k, &d, MDB_LAST);
 				}
 				batch = 0;
 			}

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_stat.1
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_stat.1
@@ -1,5 +1,5 @@
-.TH MDB_STAT 1 "2015/09/30" "LMDB 0.9.17"
-.\" Copyright 2012-2018 Howard Chu, Symas Corp. All Rights Reserved.
+.TH MDB_STAT 1 "2017/07/31" "LMDB 0.9.70"
+.\" Copyright 2012-2019 Howard Chu, Symas Corp. All Rights Reserved.
 .\" Copying restrictions apply.  See COPYRIGHT/LICENSE.
 .SH NAME
 mdb_stat \- LMDB environment status tool
@@ -13,6 +13,8 @@ mdb_stat \- LMDB environment status tool
 .BR \-f [ f [ f ]]]
 [\c
 .BR \-n ]
+[\c
+.BR \-v ]
 [\c
 .BR \-r [ r ]]
 [\c
@@ -38,6 +40,10 @@ If \fB\-fff\fP is given, display the full list of page IDs in the freelist.
 .TP
 .BR \-n
 Display the status of an LMDB database which does not use subdirectories.
+.TP
+.BR \-v
+Use the previous environment state instead of the latest state.
+This may be useful if the latest state has been corrupted.
 .TP
 .BR \-r
 Display information about the environment reader table.

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_stat.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_stat.c
@@ -34,7 +34,7 @@ static void prstat(MDB_stat *ms)
 
 static void usage(char *prog)
 {
-	fprintf(stderr, "usage: %s [-V] [-n] [-e] [-r[r]] [-f[f[f]]] [-a|-s subdb] dbpath\n", prog);
+	fprintf(stderr, "usage: %s [-V] [-n] [-e] [-r[r]] [-f[f[f]]] [-v] [-a|-s subdb] dbpath\n", prog);
 	exit(EXIT_FAILURE);
 }
 
@@ -61,6 +61,7 @@ int main(int argc, char *argv[])
 	 * -f: print freelist info
 	 * -r: print reader info
 	 * -n: use NOSUBDIR flag on env_open
+	 * -v: use previous metapage
 	 * -V: print version and exit
 	 * (default) print stat of only the main DB
 	 */
@@ -83,6 +84,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'n':
 			envflags |= MDB_NOSUBDIR;
+			break;
+		case 'v':
+			envflags |= MDB_PREVMETA;
 			break;
 		case 'r':
 			rdrinfo++;

--- a/cppForSwig/lmdb/libraries/liblmdb/mdb_stat.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/mdb_stat.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
 	 * -f: print freelist info
 	 * -r: print reader info
 	 * -n: use NOSUBDIR flag on env_open
-	 * -v: use previous metapage
+	 * -v: use previous snapshot
 	 * -V: print version and exit
 	 * (default) print stat of only the main DB
 	 */
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
 			envflags |= MDB_NOSUBDIR;
 			break;
 		case 'v':
-			envflags |= MDB_PREVMETA;
+			envflags |= MDB_PREVSNAPSHOT;
 			break;
 		case 'r':
 			rdrinfo++;

--- a/cppForSwig/lmdb/libraries/liblmdb/midl.c
+++ b/cppForSwig/lmdb/libraries/liblmdb/midl.c
@@ -3,7 +3,7 @@
 /* $OpenLDAP$ */
 /* This work is part of OpenLDAP Software <http://www.openldap.org/>.
  *
- * Copyright 2000-2018 The OpenLDAP Foundation.
+ * Copyright 2000-2019 The OpenLDAP Foundation.
  * Portions Copyright 2001-2018 Howard Chu, Symas Corp.
  * All rights reserved.
  *

--- a/cppForSwig/lmdb/libraries/liblmdb/midl.h
+++ b/cppForSwig/lmdb/libraries/liblmdb/midl.h
@@ -12,7 +12,7 @@
 /* This work is part of OpenLDAP Software <http://www.openldap.org/>.
  *
  * Copyright 2000-2019 The OpenLDAP Foundation.
- * Portions Copyright 2001-2018 Howard Chu, Symas Corp.
+ * Portions Copyright 2001-2019 Howard Chu, Symas Corp.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,11 +56,7 @@ typedef MDB_ID *MDB_IDL;
 /* IDL sizes - likely should be even bigger
  *   limiting factors: sizeof(ID), thread stack size
  */
-#ifdef MDB_VL32
-#define	MDB_IDL_LOGN	14	/* DB_SIZE is 2^14, UM_SIZE is 2^15 */
-#else
 #define	MDB_IDL_LOGN	16	/* DB_SIZE is 2^16, UM_SIZE is 2^17 */
-#endif
 #define MDB_IDL_DB_SIZE		(1<<MDB_IDL_LOGN)
 #define MDB_IDL_UM_SIZE		(1<<(MDB_IDL_LOGN+1))
 

--- a/cppForSwig/lmdb/libraries/liblmdb/midl.h
+++ b/cppForSwig/lmdb/libraries/liblmdb/midl.h
@@ -11,7 +11,7 @@
 /* $OpenLDAP$ */
 /* This work is part of OpenLDAP Software <http://www.openldap.org/>.
  *
- * Copyright 2000-2018 The OpenLDAP Foundation.
+ * Copyright 2000-2019 The OpenLDAP Foundation.
  * Portions Copyright 2001-2018 Howard Chu, Symas Corp.
  * All rights reserved.
  *


### PR DESCRIPTION
Patches integrated by cherry picking the  patches from 561ba50158f45d85894667e41050b5d0f29fc132 upwards  up until current master version 0.9.24 of LLDB. The same repository [https://github.com/LMDB/lmdb] was used which is a read-only mirror of OpenLDAP llmdb where it's activity developed. 

each commit has been give the commit ref for cross reference. and three test cases were ran to validate the results.

* SupernodeTest
* WalletTest
* CppBlockUtilsTests

which all test compare equality to the master.

git-subtree-split: 561ba50158f45d85894667e41050b5d0f29fc132