### PR TITLE
Disable file logging

### DIFF
--- a/cppForSwig/main.cpp
+++ b/cppForSwig/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
    bdmConfig.parseArgs(argc, argv);
    
    //cout << "logging in " << bdmConfig.logFilePath_ << endl;
-   //STARTLOGGING(bdmConfig.logFilePath_, LogLvlDebug);
+   STARTLOGGING("", LogLvlDebug);
    if (!bdmConfig.useCookie_)
       LOGENABLESTDOUT();
    else

--- a/cppForSwig/main.cpp
+++ b/cppForSwig/main.cpp
@@ -38,8 +38,8 @@ int main(int argc, char* argv[])
    BlockDataManagerConfig bdmConfig;
    bdmConfig.parseArgs(argc, argv);
    
-   cout << "logging in " << bdmConfig.logFilePath_ << endl;
-   STARTLOGGING(bdmConfig.logFilePath_, LogLvlDebug);
+   //cout << "logging in " << bdmConfig.logFilePath_ << endl;
+   //STARTLOGGING(bdmConfig.logFilePath_, LogLvlDebug);
    if (!bdmConfig.useCookie_)
       LOGENABLESTDOUT();
    else


### PR DESCRIPTION
ASAN reported error from logging. I think that's because some data race when logging file is accessed (looks like it's not protected and I doubt std::ofstream is thread-safe). Let's disable file logging as this is not very important feature (as it's just duplicate stdout logging).
[asan_report3.txt](https://github.com/BlockSettle/ArmoryDB/files/3991147/asan_report3.txt)
