### PR TITLE
[windows] Avoid printing the full file path on stdout logging

### DIFF
--- a/cppForSwig/log.h
+++ b/cppForSwig/log.h
@@ -68,7 +68,13 @@
 #include <atomic>
 #include "OS_TranslatePath.h"
 
+#ifdef _WIN32
+#define __FILE_NAME__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+#define FILEANDLINE "(" << __FILE_NAME__ << ":" << __LINE__ << ") "
+#else
 #define FILEANDLINE "(" << __FILE__ << ":" << __LINE__ << ") "
+#endif
+
 #define LOGERR    (LoggerObj(LogLvlError ).getLogStream() << FILEANDLINE )
 #define LOGWARN   (LoggerObj(LogLvlWarn  ).getLogStream() << FILEANDLINE )
 #define LOGINFO   (LoggerObj(LogLvlInfo  ).getLogStream() << FILEANDLINE )


### PR DESCRIPTION
Avoid exposing compile time file paths on windows builds.